### PR TITLE
Update documentation to include DO-278A language and objective mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,35 @@ Non-goals may be revisited if the threat model or invariants change. For example
 
 ---
 
+## Assurance Model
+
+**This project is not certified.**
+
+It is architected and developed with reference to the integrity objectives of DO-278A (Software Integrity Level 3), including integrity allocation, explicit assumptions, formal verification of integrity-critical logic, and traceability of requirements to verification artifacts.
+
+Formal certification is out of scope due to lack of operational deployment, certification authority, and independent verification resources. This is a single-developer project.
+
+### Integrity Allocation
+
+| Component | Integrity Level | Rationale |
+|-----------|-----------------|-----------|
+| SPARK Core | High | Integrity-critical: URL validation, short code generation. Formally verified. |
+| Haskell Service | Supporting | Network I/O, storage, rate limiting. Property-tested. |
+
+### What This Means
+
+The project is **not intended for safety-critical deployment**, but is structured similarly to DO-278A systems:
+
+- Formally proven core with explicit postconditions
+- Documented assumptions at proof boundaries (`pragma Assume`)
+- Lower-integrity service layer for I/O and orchestration
+- High-level requirements defined as invariants and non-goals
+- Verification evidence via GNATprove and Hedgehog property tests
+
+See [ROADMAP.md](docs/ROADMAP.md#do-278a-sil-3-mapping) for detailed objective mapping.
+
+---
+
 ## Documentation
 
 - **[Architecture](docs/)** - Design philosophy and dual-language approach

--- a/docs/README.md
+++ b/docs/README.md
@@ -287,9 +287,23 @@ See [LICENSES/](/LICENSES/) for full license texts.
 
 ---
 
+## Assurance Model
+
+This project references DO-278A (Software Integrity Level 3) objectives for:
+- Integrity allocation between high-integrity core and supporting service layer
+- Explicit assumption documentation at proof boundaries
+- Verification evidence via formal proofs and property tests
+
+See [ROADMAP.md](ROADMAP.md#do-278a-sil-3-mapping) for detailed objective mapping.
+
+**This project is not certified.** It is a single-developer project without certification authority or independent verification resources.
+
+---
+
 ## References
 
 This design draws from:
 - Embedded systems design principles
 - High-assurance software engineering
 - Infrastructure-first thinking
+- DO-278A integrity objectives (where applicable)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -170,6 +170,48 @@ The following will **not** be added to maintain scope:
 
 ---
 
+## DO-278A SIL-3 Mapping
+
+This project is designed and developed following the principles of DO-278A Software Integrity Level 3, where applicable. This is a single-developer project without certification authority or independent verification resources.
+
+### Objective Status
+
+| DO-278A Objective | hadlink Status | Notes |
+|-------------------|----------------|-------|
+| **Integrity Allocation** | ✓ Complete | SPARK core (high-integrity) / Haskell service (supporting) |
+| **Deterministic Core Behavior** | ✓ Complete | SPARK proves termination, bounded execution, no exceptions |
+| **Input Validation** | ✓ Complete | URL validation with proven postconditions |
+| **Assumption Documentation** | ✓ Complete | `pragma Assume` with rationale comments at proof boundaries |
+| **Verification Evidence** | ✓ Complete | GNATprove output (91 checks), Hedgehog tests (17 properties) |
+| **High-Level Requirements** | ✓ Complete | Invariants, non-goals, security constraints, abuse mitigation |
+| **Traceability** | Partial | Requirements documented; formal traceability matrix out of scope |
+| **Defined Baselines** | Out of Scope | Git tags serve as informal baselines |
+| **Change Classification** | Out of Scope | Single-developer workflow |
+| **Independent QA** | Out of Scope | No independent verification resources |
+| **Tool Qualification** | Out of Scope | See [GNATprove qualification](https://docs.adacore.com/live/wave/spark2014/html/spark2014_ug/en/usage_scenarios.html#tool-qualification) |
+
+### Component Integrity Levels
+
+| Component | Level | Verification Method |
+|-----------|-------|---------------------|
+| `Core.Canonicalize` | High | Formal proof (GNATprove) |
+| `Core.Make_Short_Code` | High | Formal proof (GNATprove) |
+| `Core_FFI` | High | Thin wrapper, no logic |
+| Haskell API | Supporting | Property tests (Hedgehog) |
+| Rate Limiter | Supporting | Property tests (Hedgehog) |
+| Storage Layer | Supporting | Integration tests |
+
+### Explicitly Out of Scope
+
+- Formal certification process
+- DO-278A documentation package
+- Independent verification and validation (IV&V)
+- Certification authority engagement
+- Tool qualification evidence package
+- Requirements management system integration
+
+---
+
 ## Contributing
 
 See `CONTRIBUTING.md` for how to help with specific milestones.


### PR DESCRIPTION
This PR includes DO-278A specific language and statements regarding `hadlink`. If the claim of "high-assurance" is retained, attention must be given to assurance certifications and guidelines such as RTCA DO-278A
(Software Integrity Assurance Considerations for Communication, Navigation, Surveillance and Air Traffic Management (CNS/ATM) Systems). `hadlink` follows many of these guidelines, but explicit statements are made for those that are not applicable or out-of-scope.