### PR TITLE
Proof of work integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Debug checked-out commit
+        run: |
+          echo "github.sha = ${{ github.sha }}"
+          git rev-parse HEAD
+          git log -1 --oneline
 
       - name: Cache Alire
         uses: actions/cache@v4

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,6 +13,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Debug checked-out commit
+        run: |
+          echo "github.sha = ${{ github.sha }}"
+          git rev-parse HEAD
+          git log -1 --oneline
 
       - name: Cache Alire
         uses: actions/cache@v4
@@ -264,8 +273,8 @@ jobs:
 
       - name: Start server with PoW enabled
         run: |
-          # Start server with PoW difficulty 4 (requires 4 leading zero bits)
-          HADLINK_PORT=8080 HADLINK_POW_DIFFICULTY=4 HADLINK_API_KEYS=test redo run-shorten &
+          # Start server with PoW: anonymous=4, authenticated=0 (bypass)
+          HADLINK_PORT=8080 HADLINK_POW_DIFFICULTY=4 HADLINK_POW_DIFFICULTY_AUTH=0 HADLINK_API_KEYS=test redo run-shorten &
           POW_SERVER_PID=$!
           echo "POW_SERVER_PID=$POW_SERVER_PID" >> $GITHUB_ENV
 
@@ -319,9 +328,9 @@ jobs:
             FAILED=$((FAILED + 1))
           fi
 
-          # Test 15: API key bypasses PoW requirement
+          # Test 15: API key bypasses PoW requirement (DIFFICULTY_AUTH=0)
           echo "" | tee -a pow-integration-output.log
-          echo "Test 15: API key bypasses PoW" | tee -a pow-integration-output.log
+          echo "Test 15: API key bypasses PoW (auth difficulty=0)" | tee -a pow-integration-output.log
           RESPONSE=$(curl -s -X POST http://localhost:8080/api/create \
             -H "X-API-Key: test" \
             -d "url=https://example.com/api-key-bypass")

--- a/.github/workflows/prove.yml
+++ b/.github/workflows/prove.yml
@@ -13,6 +13,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Debug checked-out commit
+        run: |
+          echo "github.sha = ${{ github.sha }}"
+          git rev-parse HEAD
+          git log -1 --oneline
 
       - name: Cache Alire
         uses: actions/cache@v4

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -13,6 +13,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Debug checked-out commit
+        run: |
+          echo "github.sha = ${{ github.sha }}"
+          git rev-parse HEAD
+          git log -1 --oneline
 
       - name: Cache Alire
         uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Debug checked-out commit
+        run: |
+          echo "github.sha = ${{ github.sha }}"
+          git rev-parse HEAD
+          git log -1 --oneline
 
       - name: Cache Alire
         uses: actions/cache@v4

--- a/default.do
+++ b/default.do
@@ -25,5 +25,5 @@ Example workflow:
   redo test           # Run tests
   redo prove          # Run SPARK proofs
 
-For more information, see docs/DESIGN.md
+For more information, see docs/README.md
 EOF

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -32,7 +32,7 @@ Follow the migration plan: Haskell-only → SPARK extraction → frozen API.
 
 ### Deliverables
 - [x] Working Haskell implementation
-- [x] Comprehensive test suite (21 property tests, 100 iterations each)
+- [x] Comprehensive test suite (24 property tests, 100 iterations each)
 - [x] Documentation of invariants
 - [x] Initial deployment (Docker + systemd)
 
@@ -165,7 +165,7 @@ The following will **not** be added to maintain scope:
 **Achievements**:
 - FFI integration complete: Haskell calls SPARK core for URL validation and short code generation
 - Near Gold-level SPARK proofs: Business logic assume-free, 2 pragma Assume confined to ghost lemma (see [GOLD_LEVEL_PROOFS.md](GOLD_LEVEL_PROOFS.md))
-- Comprehensive property test suite: 21 Hedgehog tests covering canonicalization, short codes, negative cases, rate limiting, and proof-of-work
+- Comprehensive property test suite: 24 Hedgehog tests covering canonicalization, short codes, negative cases, rate limiting, proof-of-work, and difficulty selection
 - Rate limiting implemented and tested: Token bucket per IP with configurable limits
 
 ---
@@ -182,7 +182,7 @@ This project is designed and developed following the principles of DO-278A Softw
 | **Deterministic Core Behavior** | ✓ Complete | SPARK proves termination, bounded execution, no exceptions |
 | **Input Validation** | ✓ Complete | URL validation with proven postconditions |
 | **Assumption Documentation** | ✓ Complete | 2 `pragma Assume` confined to ghost lemma with rationale; see [GOLD_LEVEL_PROOFS.md](GOLD_LEVEL_PROOFS.md) |
-| **Verification Evidence** | ✓ Complete | GNATprove output (111 checks), Hedgehog tests (21 properties) |
+| **Verification Evidence** | ✓ Complete | GNATprove output (111 checks), Hedgehog tests (24 properties) |
 | **High-Level Requirements** | ✓ Complete | Invariants, non-goals, security constraints, abuse mitigation |
 | **Traceability** | Partial | Requirements documented; formal traceability matrix out of scope |
 | **Defined Baselines** | Out of Scope | Git tags serve as informal baselines |

--- a/haskell/app/Main.hs
+++ b/haskell/app/Main.hs
@@ -52,14 +52,17 @@ runShortenDaemon = do
     storagePath <- getEnvWithDefault "HADLINK_STORAGE" "./hadlink.db"
     secretStr <- getEnvWithDefault "HADLINK_SECRET" "CHANGE_ME_INSECURE_DEFAULT"
     powDiffStr <- getEnvWithDefault "HADLINK_POW_DIFFICULTY" "0"
+    powDiffAuthStr <- getEnvWithDefault "HADLINK_POW_DIFFICULTY_AUTH" "0"
     apiKeysStr <- getEnvWithDefault "HADLINK_API_KEYS" ""
 
     let secret = BS8.pack secretStr
         powDifficulty = read powDiffStr
+        powDifficultyAuth = read powDiffAuthStr
         apiKeys = parseAPIKeys apiKeysStr
         config = Config
           { cfgSecret = secret
           , cfgPowDifficulty = Difficulty powDifficulty
+          , cfgPowDifficultyAuth = Difficulty powDifficultyAuth
           , cfgRateLimitPerIP = 10
           , cfgRateLimitWindow = 60
           , cfgStoragePath = storagePath
@@ -68,7 +71,7 @@ runShortenDaemon = do
 
     putStrLn $ "Starting shorten daemon on port " ++ show port
     putStrLn $ "Storage: " ++ storagePath
-    putStrLn $ "PoW difficulty: " ++ show powDifficulty ++ " (0 = disabled)"
+    putStrLn $ "PoW difficulty: " ++ show powDifficulty ++ " (anonymous), " ++ show powDifficultyAuth ++ " (authenticated)"
     putStrLn $ "API keys configured: " ++ show (length apiKeys)
     putStrLn $ "Rate limit: " ++ show (cfgRateLimitPerIP config) ++ " requests per " ++ show (cfgRateLimitWindow config) ++ "s"
 
@@ -101,6 +104,7 @@ runRedirectDaemon = do
     let config = Config
           { cfgSecret = ""  -- Not used by redirect
           , cfgPowDifficulty = 0
+          , cfgPowDifficultyAuth = 0
           , cfgRateLimitPerIP = 0
           , cfgRateLimitWindow = 0
           , cfgStoragePath = storagePath

--- a/haskell/build.do
+++ b/haskell/build.do
@@ -12,7 +12,7 @@ redo-ifchange ../spark-core/build
 redo-ifchange hadlink.cabal $(find src app -name '*.hs' 2>/dev/null)
 
 echo "Building Haskell components..."
-stack build
+stack build --test --no-run-tests
 
 # Mark as successfully built
 touch "$3"

--- a/haskell/src/Types.hs
+++ b/haskell/src/Types.hs
@@ -84,10 +84,11 @@ data APIError
 
 -- | Configuration for the shortener service
 data Config = Config
-  { cfgSecret          :: ByteString  -- HMAC secret for short codes
-  , cfgPowDifficulty   :: Difficulty  -- PoW difficulty (0 = disabled)
-  , cfgRateLimitPerIP  :: Int         -- Max requests per IP per window
-  , cfgRateLimitWindow :: Int         -- Rate limit window in seconds
-  , cfgStoragePath     :: FilePath    -- Path to storage backend
-  , cfgAPIKeys         :: [APIKey]    -- Authorized API keys (bypass PoW)
+  { cfgSecret              :: ByteString  -- HMAC secret for short codes
+  , cfgPowDifficulty       :: Difficulty  -- PoW difficulty for anonymous requests (0 = disabled)
+  , cfgPowDifficultyAuth   :: Difficulty  -- PoW difficulty for authenticated requests (0 = bypass)
+  , cfgRateLimitPerIP      :: Int         -- Max requests per IP per window
+  , cfgRateLimitWindow     :: Int         -- Rate limit window in seconds
+  , cfgStoragePath         :: FilePath    -- Path to storage backend
+  , cfgAPIKeys             :: [APIKey]    -- Authorized API keys
   } deriving (Show, Eq, Generic)


### PR DESCRIPTION
This PR integrates proof-of-work abuse mitigation by requiring clients to compute a valid nonce. The client must find a nonce such that `SHA256(canonical_url || nonce)` has a specified number of leading zero bits, making link creation computationally expensive while keeping verification trivial.

PoW is disabled by default, with `HADLINK_POW_DIFFICULTY` is set to `0`. The difficulty value corresponds to the number of leading zero bits required. Each increment doubles the required work. API key bypass is possible, with a  separately configurable `HADLINK_POW_DIFFICULTY_AUTH` which may be set to `0` to disable, or allow reduced difficulty.